### PR TITLE
Fix npm ci peer dependency conflict in Amplify build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,13 +3,13 @@ backend:
   phases:
     build:
       commands:
-        - npm ci --cache .npm --prefer-offline
+        - npm ci --cache .npm --prefer-offline --legacy-peer-deps
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
     preBuild:
       commands:
-        - npm ci --cache .npm --prefer-offline
+        - npm ci --cache .npm --prefer-offline --legacy-peer-deps
     build:
       commands:
         - npm run build


### PR DESCRIPTION
react-scripts and @aws-amplify/backend-cli have conflicting typescript peer deps; --legacy-peer-deps resolves it the same way local installs do.