### PR TITLE
Switch from npm ci to npm install to fix lockfile mismatch in CI

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,13 +3,13 @@ backend:
   phases:
     build:
       commands:
-        - npm ci --cache .npm --prefer-offline --legacy-peer-deps
+        - npm install --legacy-peer-deps
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
     preBuild:
       commands:
-        - npm ci --cache .npm --prefer-offline --legacy-peer-deps
+        - npm install --legacy-peer-deps
     build:
       commands:
         - npm run build


### PR DESCRIPTION
The lockfile generated on Node 25 is missing transitive deps that the Amplify build environment (Node 18) expects from @aws-amplify/backend-cli. npm install resolves deps fresh from package.json, avoiding the strict sync check.