### PR TITLE
Install backend-cli in isolated dir to avoid global amplify binary co…

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,8 +3,8 @@ backend:
   phases:
     build:
       commands:
-        - npm install -g @aws-amplify/backend-cli
-        - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
+        - npm install --prefix /tmp/ampx-install @aws-amplify/backend-cli
+        - /tmp/ampx-install/node_modules/.bin/ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
     preBuild:


### PR DESCRIPTION
…nflict

Amplify Hosting auto-installs @aws-amplify/cli globally before our build, so npm install -g @aws-amplify/backend-cli fails with EEXIST on the amplify binary. Install into /tmp/ampx-install and invoke directly from there.