### PR TITLE
Set npm_config_user_agent when invoking ampx directly

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ backend:
     build:
       commands:
         - npm install --prefix /tmp/ampx-install @aws-amplify/backend-cli
-        - /tmp/ampx-install/node_modules/.bin/ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
+        - npm_config_user_agent="npm" /tmp/ampx-install/node_modules/.bin/ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
     preBuild:


### PR DESCRIPTION
ampx requires this env var (normally set by npx) to detect the package manager. Set it inline since we're calling the binary directly.