### PR TITLE
Install @aws-amplify/backend in project before pipeline-deploy

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,6 +4,7 @@ backend:
     build:
       commands:
         - npm install --prefix /tmp/ampx-install @aws-amplify/backend-cli
+        - npm install --no-save --legacy-peer-deps @aws-amplify/backend
         - npm_config_user_agent="npm" /tmp/ampx-install/node_modules/.bin/ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:


### PR DESCRIPTION
ampx compiles amplify/data/resource.ts which imports from @aws-amplify/backend. TypeScript resolves imports from the project directory, not the CLI install location, so it must be present in the project's node_modules.