### PR TITLE
Install all CDK peer deps needed by @aws-amplify/backend

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ backend:
     build:
       commands:
         - npm install --prefix /tmp/ampx-install @aws-amplify/backend-cli
-        - npm install --no-save --legacy-peer-deps @aws-amplify/backend aws-cdk-lib
+        - npm install --no-save --legacy-peer-deps @aws-amplify/backend aws-cdk-lib constructs typescript
         - npm_config_user_agent="npm" /tmp/ampx-install/node_modules/.bin/ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:


### PR DESCRIPTION
aws-cdk-lib, constructs, and typescript are all peer deps that --legacy-peer-deps skips. Install them explicitly so CDK assembly succeeds.