### PR TITLE
Use .js extension in ESM import in amplify/backend.ts

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,5 +1,5 @@
 import { defineBackend } from '@aws-amplify/backend';
-import { data } from './data/resource';
+import { data } from './data/resource.js';
 
 defineBackend({
   data,


### PR DESCRIPTION
Node.js native ESM requires explicit file extensions. TypeScript resolves .ts files for .js imports, so this is the correct pattern for TS+ESM.