### PR TITLE
Unify deps approach: put all backend deps in package.json, use npx ampx

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,9 +3,8 @@ backend:
   phases:
     build:
       commands:
-        - npm install --prefix /tmp/ampx-install @aws-amplify/backend-cli
-        - npm install --no-save --legacy-peer-deps @aws-amplify/backend aws-cdk-lib constructs typescript
-        - npm_config_user_agent="npm" /tmp/ampx-install/node_modules/.bin/ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
+        - npm install --legacy-peer-deps
+        - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
     preBuild:

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,5 +1,5 @@
 import { defineBackend } from '@aws-amplify/backend';
-import { data } from './data/resource.js';
+import { data } from './data/resource';
 
 defineBackend({
   data,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
     "websocket-extensions": "0.1.4",
     "yarn-audit-fix": "^10.1.1"
   },
+  "devDependencies": {
+    "@aws-amplify/backend": "^1.0.0",
+    "@aws-amplify/backend-cli": "^1.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0",
+    "typescript": "^5.0.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
The isolated /tmp install caused ampx to fail loading TypeScript source from the project directory. Fix by putting @aws-amplify/backend-cli, @aws-amplify/backend, aws-cdk-lib, constructs, and typescript as explicit devDependencies so npm resolves them all together. --legacy-peer-deps handles the react-scripts/typescript version conflict as a warning, not an error.