### PR TITLE
Add amplify/package.json with type:module

### DIFF
--- a/amplify/package.json
+++ b/amplify/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "amplify",
+  "version": "1.0.0",
+  "type": "module"
+}


### PR DESCRIPTION
Required by the standard npm create amplify scaffold. Without it, Node.js treats .js files in the amplify/ dir as CommonJS and can't resolve ESM imports during CDK assembly.